### PR TITLE
Fix Keycode Issue in Firefox

### DIFF
--- a/mention/plugin.js
+++ b/mention/plugin.js
@@ -355,7 +355,8 @@
             }
 
             ed.on('keypress', function (e) {
-                var delimiterIndex = $.inArray(String.fromCharCode(e.which || e.keyCode), autoCompleteData.delimiter);
+                var keyCode = (typeof e.which == 'number') ? e.which : e.keyCode;
+                var delimiterIndex = $.inArray(String.fromCharCode(keyCode), autoCompleteData.delimiter);
                 if (delimiterIndex > -1 && prevCharIsSpace()) {
                     if (autoComplete === undefined || (autoComplete.hasFocus !== undefined && !autoComplete.hasFocus)) {
                         e.preventDefault();


### PR DESCRIPTION
In firefox, lookup is getting triggered when going back (left arrow) through content and doing lookup when it hits a space. 
The issue was because e.which was 0 
which was falling back to e.keyCode 
which was 37
and String.fromCharCode(37) equaled our delimiter 
which was a '%'
